### PR TITLE
Merge finite difference improvements.

### DIFF
--- a/src/rose/utility.py
+++ b/src/rose/utility.py
@@ -3,41 +3,64 @@ Useful utility functions that I don't want to clutter up other modules with.
 '''
 import numpy as np
 import numpy.typing as npt
-from scipy.sparse import diags
+from scipy.sparse import diags, lil_matrix
 
 def finite_difference_first_derivative(
-    s_mesh: npt.ArrayLike
+    s_mesh: npt.ArrayLike,
+    sparse: bool = False
 ):
     '''
     Computes a finite difference matrix that (when applied) represent the first
     derivative.
     '''
-    ds = s_mesh[1] - s_mesh[0]
-    assert np.all(np.abs(s_mesh[1:] - s_mesh[:-1] - ds) < 1e-14), '''
+    dx = s_mesh[1] - s_mesh[0]
+    assert np.all(np.abs(s_mesh[1:] - s_mesh[:-1] - dx) < 1e-14), '''
 Spacing must be consistent throughout the entire mesh.
     '''
-    ns = s_mesh.size
-    D1 = diags([1, -8, 8, -1], [-2, -1, 1, 2], shape=(ns, ns)).toarray() / (12*ds)
-    D1[0, 0] = -3/(2*ds)
-    D1[0, 1] = 4/(2*ds)
-    D1[0, 2] = -1/(2*ds)
+    n = s_mesh.size
+    coefficients = np.array([1, -8, 8, -1]) / (12*dx)
+    if sparse:
+        D1 = lil_matrix(diags(coefficients, [-2, -1, 1, 2], shape=(n, n)))
+    else:
+        D1 = lil_matrix(diags(coefficients, [-2, -1, 1, 2], shape=(n, n))).toarray()
+
+    # Use O(dx^2) forward difference approximations for the first 2 rows.
+    D1[0, :5] = np.array([-3, 4, -1, 0, 0]) / (2*dx)
+    D1[1, :5] = np.array([0, -3, 4, -1, 0]) / (2*dx)
+
+    # Use O(dx^2) backward difference approximations for the last 2 rows.
+    D1[-2, -5:] = np.array([0, 1, -4, 3, 0]) / (2*dx)
+    D1[-1, -5:] = np.array([0, 0, 1, -4, 3]) / (2*dx)
+
     return D1
 
 
+
 def finite_difference_second_derivative(
-    s_mesh: npt.ArrayLike
+    s_mesh: npt.ArrayLike,
+    sparse: bool = False
 ):
     '''
     Computes a finite difference matrix that represents the second derivative
     (w.r.t. s or rho) operator in coordinate space.
     '''
-    ds = s_mesh[1] - s_mesh[0]
-    assert np.all(np.abs(s_mesh[1:] - s_mesh[:-1] - ds) < 1e-14), '''
+    dx = s_mesh[1] - s_mesh[0]
+    assert np.all(np.abs(s_mesh[1:] - s_mesh[:-1] - dx) < 1e-14), '''
 Spacing must be consistent throughout the entire mesh.
     '''
-    ns = s_mesh.size
-    D2 = diags([-30, 16, 16, -1, -1], [0, 1, -1, 2, -2], shape=(ns, ns)).toarray() / (12*ds**2)
-    D2[0, 0] = -2/ds**2
-    D2[0, 1] = 1/ds**2
-    D2[0, 2] = 0
+    n = s_mesh.size
+    coefficients = np.array([-1, 16, -30, 16, -1]) / (12*dx**2)
+    if sparse:
+        D2 = lil_matrix(diags(coefficients, [-2, -1, 0, 1, 2], shape=(n, n)))
+    else:
+        D2 = diags(coefficients, [-2, -1, 0, 1, 2], shape=(n, n)).toarray()
+
+    # Use O(dx^2) forward difference approximation for the first 2 rows.
+    D2[0, :5] = np.array([2, -5, 4, -1, 0]) / dx**2
+    D2[1, :5] = np.array([0, 2, -5, 4, -1]) / dx**2
+
+    # Use O(dx^2) backward difference approximation for the last 2 rows.
+    D2[-2, -5:] = np.array([-1, 4, -5, 2, 0]) / dx**2 
+    D2[-1, -5:] = np.array([0, -1, 4, -5, 2]) / dx**2 
+
     return D2


### PR DESCRIPTION
I have updated the functions in `utility.py` to use higher accuracy finite difference matrices. I have also updated `ReducedBasisEmulator` to no longer discard the first and last 2 points from results of applying these matrices (a small thing that bugged me – but not for a good reason).

I have tested this with the Minnesota potential, but I'd like someone else to install on the `finite_diff` branch and confirm that emulator results are still sufficiently accurate.